### PR TITLE
Add support for equinox automatic updates type

### DIFF
--- a/update-package-via-manifest/package-lock.json
+++ b/update-package-via-manifest/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.4.0",
         "@actions/github": "^5.0.0",
+        "axios": "^0.26.1",
         "glob": "^7.1.7",
         "glob-promise": "^4.2.0"
       },
@@ -464,6 +465,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -801,6 +810,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -2263,6 +2291,14 @@
         "color-convert": "^2.0.1"
       }
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2528,6 +2564,11 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/update-package-via-manifest/package.json
+++ b/update-package-via-manifest/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@actions/core": "^1.4.0",
     "@actions/github": "^5.0.0",
+    "axios": "^0.26.1",
     "glob": "^7.1.7",
     "glob-promise": "^4.2.0"
   }

--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -34,6 +34,9 @@ try {
 				}
 				latestVersion = ghVersion.replace(/^v/m, "") // Remove leading v idiom
 				break
+			case "equinox":
+				core.warning("equinox automaticUpdates type is not yet implemented")
+				continue
 			default:
 				core.warning(`Unknown automaticUpdates type '${manifest.automaticUpdates}' in ${manifestPath}`)
 				continue

--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -67,11 +67,19 @@ try {
 
 		fs.writeFileSync(pkgbuildPath, pkgbuildContents)
 
-		// Update checksums in PKGBUILD
-		execSync(`updpkgsums`, {
-			stdio: "inherit",
-			cwd: manifestPath.replace("/.aurmanifest.json", ""),
-		})
+		// Only update the checksums in PKGBUILD when the manifest type supports it.
+		//
+		// For example, GitHub urls will update cleanly with the package version, but
+		// equinox.io uses random strings in their urls that have to be updated manually.
+		// To prevent errors from updpkgsums, we skip the checksum update and rely on
+		// maintainers to do it properly.
+		if (["github"].indexOf(manifest.automaticUpdates.type) !== -1) {
+			// Update checksums in PKGBUILD
+			execSync(`updpkgsums`, {
+				stdio: "inherit",
+				cwd: manifestPath.replace("/.aurmanifest.json", ""),
+			})
+		}
 
 		// git add and commit updated PKGBUILD
 		execSync(`git add ${pkgbuildPath}`, { stdio: 'inherit' })

--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -35,8 +35,13 @@ try {
 				latestVersion = ghVersion.replace(/^v/m, "") // Remove leading v idiom
 				break
 			case "equinox":
-				core.warning("equinox automaticUpdates type is not yet implemented")
-				continue
+				const eqVer = await getLatestVersionFromEquinox(manifest.automaticUpdates.appID)
+				if (eqVer === undefined) {
+					core.warning(`Failed to get latest version from Equinox (${manifestPath}).`)
+					continue
+				}
+				latestVersion = eqVer
+				break
 			default:
 				core.warning(`Unknown automaticUpdates type '${manifest.automaticUpdates}' in ${manifestPath}`)
 				continue
@@ -155,6 +160,15 @@ async function getLatestVersionFromGithub(repo: string): Promise<string | undefi
 	return resp.data.tag_name
 }
 
+async function getLatestVersionFromEquinox(appID: string): Promise<string | undefined> {
+	// TODO: Send request to equinox.io
+
+	// TODO: Parse request for latest version
+
+	// TODO: Return latest version
+	return ""
+}
+
 interface IManifest {
 	name: string,
 	testCmd: string | null,
@@ -162,6 +176,7 @@ interface IManifest {
 	automaticUpdates: {
 		type: string,
 		repo: string,
+		appID: string,
 	}
 }
 

--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -44,7 +44,7 @@ try {
 				latestVersion = eqVer
 				break
 			default:
-				core.warning(`Unknown automaticUpdates type '${manifest.automaticUpdates}' in ${manifestPath}`)
+				core.warning(`Unknown automaticUpdates type '${manifest.automaticUpdates.type}' in ${manifestPath}`)
 				continue
 		}
 

--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -4,6 +4,7 @@ import { promise as glob } from "glob-promise"
 import * as fs from "fs"
 import * as path from "path"
 import { execSync } from "child_process"
+import axios from "axios"
 
 try {
 	const context = github.context
@@ -161,12 +162,24 @@ async function getLatestVersionFromGithub(repo: string): Promise<string | undefi
 }
 
 async function getLatestVersionFromEquinox(appID: string): Promise<string | undefined> {
-	// TODO: Send request to equinox.io
+	// Send request to equinox.io
+	const result = await axios.post("https://update.equinox.io/check", {
+		"app_id": appID,
+		"channel": "stable",
+		"current_sha256": "",
+		"current_version": "0.0.0",
+		"goarm": "",
+		"os": "linux",
+		"target_version": "",
+		"arch": "amd64"
+	})
 
-	// TODO: Parse request for latest version
+	if (result.status !== 200) {
+		core.warning(`Received non-200 status code from update.equinox.io. Status: ${result.statusText}(${result.status}). Data: ${result.data}`)
+		return undefined
+	}
 
-	// TODO: Return latest version
-	return ""
+	return result.data.release.version
 }
 
 interface IManifest {


### PR DESCRIPTION
This adds support for the [Equinox](https://equinox.io) updating platform as an automatic update source.

Unfortunately, a maintainer will still have to manually update source URLs before the resulting PRs can be merged, but that is a problem that can be addressed in the future.