### PR TITLE
Restructure update-package-via-manifest

### DIFF
--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -95,7 +95,13 @@ function handleManifest(manifestPath: string, pkgbuildPath: string) {
 
 	fs.writeFileSync(pkgbuildPath, pkgbuildContents)
 
-	// TODO: Run updpkgsums if requested by updateProvider
+	// Update checksums in PKGBUILD
+	if (updateData.updateChecksums) {
+		execSync(`updpkgsums`, {
+			stdio: "inherit",
+			cwd: manifestPath.replace("/.aurmanifest.json", ""),
+		})
+	}
 
 	// TODO: Commit and push changes
 

--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -1,14 +1,21 @@
 import * as core from "@actions/core"
 import * as github from "@actions/github"
-import { promise as glob } from "glob-promise"
-import * as fs from "fs"
 import * as path from "path"
-import { execSync } from "child_process"
-import axios from "axios"
+import * as fs from "fs"
+import { promise as glob } from "glob-promise"
 
-try {
-	const context = github.context
+interface IManifest {
+	name: string,
+	testCmd: string | null,
+	include: string[],
+	automaticUpdates: {
+		type: string,
+		repo: string,
+		appID: string,
+	}
+}
 
+async function main() {
 	// Identify all packages in the pkgs directory
 	const manifests = await glob("pkgs/**/.aurmanifest.json")
 
@@ -19,111 +26,34 @@ try {
 
 		const manifest = JSON.parse(fs.readFileSync(manifestPath).toString()) as IManifest
 
+		// TODO: Identify which updateProvider to use
+
 		const pkgbuildVersion: string | undefined = getVersionFromPKGBUILD(manifestPath.replace("/.aurmanifest.json", ""))
 		if (pkgbuildVersion === undefined) {
 			core.warning(`Unable to get package version from PKGBUILD (${manifest.name})`)
 			continue
 		}
 
-		let latestVersion = ""
-		switch (manifest.automaticUpdates.type) {
-			case "github":
-				const ghVersion = await getLatestVersionFromGithub(manifest.automaticUpdates.repo)
-				if (ghVersion === undefined) {
-					core.warning(`Failed to get latest version from GitHub (${manifestPath}).`)
-					continue
-				}
-				latestVersion = ghVersion.replace(/^v/m, "") // Remove leading v idiom
-				break
-			case "equinox":
-				const eqVer = await getLatestVersionFromEquinox(manifest.automaticUpdates.appID)
-				if (eqVer === undefined) {
-					core.warning(`Failed to get latest version from Equinox (${manifestPath}).`)
-					continue
-				}
-				latestVersion = eqVer
-				break
-			case undefined: // Skip if the automaticUpdates field is empty
-				continue
-			default:
-				core.warning(`Unknown automaticUpdates type '${manifest.automaticUpdates.type}' in ${manifestPath}`)
-				continue
-		}
+		// TODO: Ask updateProvider what the latest version is
 
-		core.info(`PKGBUILD: '${pkgbuildVersion}' Latest: '${latestVersion}'`)
-		if (pkgbuildVersion === latestVersion) {
-			continue
-		}
+		// TODO: Check if PKGBUILD and latest versions are the same
 
-		// Change permissions so that everything "should be" writable and so git won't complain
-		// about an unsafe directory
-		execSync("sudo chown -R builder:builder $(pwd)", { stdio: 'inherit' })
+		// TODO: Check if a PR has already been opened
 
-		core.info(execSync("git remote -v").toString())
+		// TODO: Ask updateProvider for the update data to act upon
 
-		// Check current branches for latestVersion
-		if (hasVersionAlreadyBeenPushed(manifest.name, latestVersion)) {
-			continue
-		}
+		// TODO: Update PKGBUILD with new version
 
-		// Create new branch
-		const branchName = `bot/${manifest.name}/${latestVersion}`
-		execSync(`git checkout -b ${branchName}`, { stdio: 'inherit' })
+		// TODO: Update PKGBUILD source arrays with sources (if provided by updateProvider)
 
-		let pkgbuildContents: string = fs.readFileSync(pkgbuildPath).toString()
+		// TODO: Write PKGBUILD changes to disk
 
-		// Update PKGBUILD with new version (pkgver to latestVersion and pkgrel to 1)
-		pkgbuildContents = pkgbuildContents.replace(/^pkgver=.*/m, `pkgver=${latestVersion}`)
-		pkgbuildContents = pkgbuildContents.replace(/^pkgrel=.*/m, "pkgrel=1")
+		// TODO: Run updpkgsums if requested by updateProvider
 
-		fs.writeFileSync(pkgbuildPath, pkgbuildContents)
+		// TODO: Commit and push changes
 
-		// Only update the checksums in PKGBUILD when the manifest type supports it.
-		//
-		// For example, GitHub urls will update cleanly with the package version, but
-		// equinox.io uses random strings in their urls that have to be updated manually.
-		// To prevent errors from updpkgsums, we skip the checksum update and rely on
-		// maintainers to do it properly.
-		if (["github"].indexOf(manifest.automaticUpdates.type) !== -1) {
-			// Update checksums in PKGBUILD
-			execSync(`updpkgsums`, {
-				stdio: "inherit",
-				cwd: manifestPath.replace("/.aurmanifest.json", ""),
-			})
-		}
-
-		// git add and commit updated PKGBUILD
-		execSync(`git add ${pkgbuildPath}`, { stdio: 'inherit' })
-		execSync(`git commit -m "Update ${manifest.name} to ${latestVersion}"`, {
-			stdio: "inherit",
-			env: {
-				GIT_AUTHOR_NAME: "github-actions[bot]",
-				GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com",
-				GIT_COMMITTER_NAME: "github-actions[bot]",
-				GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com",
-				EMAIL: "41898282+github-actions[bot]@users.noreply.github.com",
-			}
-		})
-
-		// Push changes to GitHub
-		execSync(`git push origin ${branchName}`, { stdio: 'inherit' })
-
-		// Create a pull request with the changes
-		const octokit = github.getOctokit(core.getInput("github-token"))
-		octokit.rest.pulls.create({
-			...context.repo,
-			head: branchName,
-			base: "master",
-			maintainer_can_modify: true,
-			title: `Update ${manifest.name} to ${latestVersion}`,
-		})
-
-		// Switch back to master branch
-		execSync(`git checkout master`, { stdio: 'inherit' })
+		// TODO: Open PR with any custom text from updateProvider
 	}
-
-} catch (error: any) {
-	core.setFailed(error)
 }
 
 function getVersionFromPKGBUILD(dir: string): string | undefined {
@@ -137,76 +67,8 @@ function getVersionFromPKGBUILD(dir: string): string | undefined {
 	return matches[1]
 }
 
-async function getLatestVersionFromGithub(repo: string): Promise<string | undefined> {
-	const split = repo.split("/")
-	const owner = split[0]
-	const repoName = split[1]
-
-	if (owner === undefined || repoName === undefined) {
-		return undefined
-	}
-
-	const octokit = github.getOctokit(core.getInput("github-token"))
-
-	let resp;
-	try {
-		resp = await octokit.rest.repos.getLatestRelease({
-			owner: owner,
-			repo: repoName,
-		})
-	} catch (e: any) {
-		core.warning(e)
-		return undefined
-	}
-
-	if (resp.status !== 200) {
-		return undefined
-	}
-
-	return resp.data.tag_name
-}
-
-async function getLatestVersionFromEquinox(appID: string): Promise<string | undefined> {
-	// Send request to equinox.io
-	const result = await axios.post("https://update.equinox.io/check", {
-		"app_id": appID,
-		"channel": "stable",
-		"current_sha256": "",
-		"current_version": "0.0.0",
-		"goarm": "",
-		"os": "linux",
-		"target_version": "",
-		"arch": "amd64"
-	})
-
-	if (result.status !== 200) {
-		core.warning(`Received non-200 status code from update.equinox.io. Status: ${result.statusText}(${result.status}). Data: ${result.data}`)
-		return undefined
-	}
-
-	return result.data.release.version
-}
-
-interface IManifest {
-	name: string,
-	testCmd: string | null,
-	include: string[],
-	automaticUpdates: {
-		type: string,
-		repo: string,
-		appID: string,
-	}
-}
-
-function hasVersionAlreadyBeenPushed(packageName: string, version: string): boolean {
-	const remoteBranches: string = execSync("git ls-remote --heads origin").toString()
-
-	for (const branch of remoteBranches.split("\n")) {
-		if (branch.indexOf(`${packageName}/${version}`) === -1) {
-			continue
-		}
-		return true
-	}
-
-	return false
+try {
+	await main()
+} catch (error: any) {
+	core.setFailed(error)
 }

--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -78,13 +78,22 @@ function handleManifest(manifestPath: string, pkgbuildPath: string) {
 	// Check current branches for latestVersion
 	if (util.hasVersionAlreadyBeenPushed(manifest.name, latestVersion)) return
 
-	// TODO: Ask updateProvider for the update data to act upon
+	const updateData = updProv.updateData(manifest.automaticUpdates)
 
-	// TODO: Update PKGBUILD with new version
+	// Create new branch so that a PR can be made later
+	const branchName = `bot/${manifest.name}/${latestVersion}`
+	execSync(`git checkout -b ${branchName}`, { stdio: 'inherit' })
 
-	// TODO: Update PKGBUILD source arrays with sources (if provided by updateProvider)
+	let pkgbuildContents: string = fs.readFileSync(pkgbuildPath).toString()
 
-	// TODO: Write PKGBUILD changes to disk
+	// Update PKGBUILD with new version (pkgver to latestVersion and pkgrel to 1)
+	pkgbuildContents = pkgbuildContents.replace(/^pkgver=.*/m, `pkgver=${latestVersion}`)
+	pkgbuildContents = pkgbuildContents.replace(/^pkgrel=.*/m, "pkgrel=1")
+
+	// Update PKGBUILD source arrays with new sources (if provided by updateProvider)
+	pkgbuildContents = util.updateSourceArrays(pkgbuildContents, updateData)
+
+	fs.writeFileSync(pkgbuildPath, pkgbuildContents)
 
 	// TODO: Run updpkgsums if requested by updateProvider
 

--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -24,7 +24,7 @@ export interface IUpdateProvider {
 	latestVersion(manifestData: any): Promise<string | undefined>,
 	updateData(manifestData: any): Promise<{
 		updateChecksums: boolean,
-		prBody?: string,
+		prContent?: string,
 		sourceArray?: Array<string>,
 		source_x86_64?: Array<string>,
 		source_i686?: Array<string>,
@@ -138,7 +138,7 @@ async function handleManifest(manifestPath: string, pkgbuildPath: string) {
 		base: "master",
 		maintainer_can_modify: true,
 		title: `Update ${manifest.name} to ${latestVersion}`,
-		body: updateData.prBody,
+		body: `${(updateData.prContent !== undefined) ? updateData.prContent + "\n\n" : ""}_This PR was opened by the automatic package updates component of the[Automatic AUR system](https://github.com/BrenekH/automated-aur#README)._`,
 	})
 
 	// Switch back to master branch

--- a/update-package-via-manifest/src/providers/equinox.ts
+++ b/update-package-via-manifest/src/providers/equinox.ts
@@ -1,12 +1,32 @@
+import * as core from "@actions/core"
+import axios from "axios"
+
 import { IUpdateProvider } from "../index"
 
 interface IManifestData {
-
+	appID: string
 }
 
 export class EquinoxUpdateProvider implements IUpdateProvider {
 	async latestVersion(manifestData: IManifestData): Promise<string | undefined> {
-		throw new Error("Method not implemented.")
+		// Send request to equinox.io
+		const result = await axios.post("https://update.equinox.io/check", {
+			"app_id": manifestData.appID,
+			"channel": "stable",
+			"current_sha256": "",
+			"current_version": "0.0.0",
+			"goarm": "",
+			"os": "linux",
+			"target_version": "",
+			"arch": "amd64"
+		})
+
+		if (result.status !== 200) {
+			core.warning(`Received non-200 status code from update.equinox.io. Status: ${result.statusText}(${result.status}). Data: ${result.data}`)
+			return undefined
+		}
+
+		return result.data.release.version
 	}
 
 	async updateData(manifestData: IManifestData): Promise<{
@@ -18,6 +38,10 @@ export class EquinoxUpdateProvider implements IUpdateProvider {
 		source_aarch64?: string[] | undefined
 		source_armv7h?: string[] | undefined
 	} | undefined> {
-		throw new Error("Method not implemented.")
+		// TODO: Request source urls for all architectures
+
+		return {
+			updateChecksums: false,
+		}
 	}
 }

--- a/update-package-via-manifest/src/providers/equinox.ts
+++ b/update-package-via-manifest/src/providers/equinox.ts
@@ -1,0 +1,23 @@
+import { IUpdateProvider } from "../index"
+
+interface IManifestData {
+
+}
+
+export class EquinoxUpdateProvider implements IUpdateProvider {
+	async latestVersion(manifestData: IManifestData): Promise<string | undefined> {
+		throw new Error("Method not implemented.")
+	}
+
+	async updateData(manifestData: IManifestData): Promise<{
+		updateChecksums: boolean
+		prBody?: string | undefined
+		sourceArray?: string[] | undefined
+		source_x86_64?: string[] | undefined
+		source_i686?: string[] | undefined
+		source_aarch64?: string[] | undefined
+		source_armv7h?: string[] | undefined
+	} | undefined> {
+		throw new Error("Method not implemented.")
+	}
+}

--- a/update-package-via-manifest/src/providers/equinox.ts
+++ b/update-package-via-manifest/src/providers/equinox.ts
@@ -31,17 +31,44 @@ export class EquinoxUpdateProvider implements IUpdateProvider {
 
 	async updateData(manifestData: IManifestData): Promise<{
 		updateChecksums: boolean
-		prBody?: string | undefined
+		prContent?: string | undefined
 		sourceArray?: string[] | undefined
 		source_x86_64?: string[] | undefined
 		source_i686?: string[] | undefined
 		source_aarch64?: string[] | undefined
 		source_armv7h?: string[] | undefined
 	} | undefined> {
-		// TODO: Request source urls for all architectures
+		const source_x86_64: string | undefined = await this.requestArchSourceURL(manifestData.appID, "amd64")
+		const source_i686: string | undefined = await this.requestArchSourceURL(manifestData.appID, "i386")
+		const source_aarch64: string | undefined = await this.requestArchSourceURL(manifestData.appID, "arm64")
+		const source_armv7h: string | undefined = await this.requestArchSourceURL(manifestData.appID, "arm")
 
 		return {
 			updateChecksums: false,
+			source_x86_64: (source_x86_64 !== undefined) ? [source_x86_64] : undefined,    // This weird series of ternary statements is all so that
+			source_i686: (source_i686 !== undefined) ? [source_i686] : undefined,          // requestArchSourceURL can return a string, but we can
+			source_aarch64: (source_aarch64 !== undefined) ? [source_aarch64] : undefined, // also still respect the array-like nature of the
+			source_armv7h: (source_armv7h !== undefined) ? [source_armv7h] : undefined,    // source parameters.
 		}
+	}
+
+	private async requestArchSourceURL(appID: string, arch: string): Promise<string | undefined> {
+		const result = await axios.post("https://update.equinox.io/check", {
+			"app_id": appID,
+			"channel": "stable",
+			"current_sha256": "",
+			"current_version": "0.0.0",
+			"goarm": "",
+			"os": "linux",
+			"target_version": "",
+			"arch": arch,
+		})
+
+		if (result.status !== 200) {
+			core.warning(`Received non-200 status code from update.equinox.io. Status: ${result.statusText}(${result.status}). Data: ${result.data}`)
+			return undefined
+		}
+
+		return result.data.download_url
 	}
 }

--- a/update-package-via-manifest/src/providers/github.ts
+++ b/update-package-via-manifest/src/providers/github.ts
@@ -43,7 +43,7 @@ export class GitHubUpdateProvider implements IUpdateProvider {
 
 	async updateData(_: IManifestData): Promise<{
 		updateChecksums: boolean
-		prBody?: string | undefined
+		prContent?: string | undefined
 		sourceArray?: string[] | undefined
 		source_x86_64?: string[] | undefined
 		source_i686?: string[] | undefined
@@ -56,7 +56,7 @@ export class GitHubUpdateProvider implements IUpdateProvider {
 
 		return {
 			updateChecksums: true,
-			prBody: `_GitHub Release Link:_ [${this.lastTagHTMLLink}](${this.lastTagHTMLLink})`
+			prContent: `_GitHub Release Link:_ [${this.lastTagHTMLLink}](${this.lastTagHTMLLink})`
 		}
 	}
 }

--- a/update-package-via-manifest/src/providers/github.ts
+++ b/update-package-via-manifest/src/providers/github.ts
@@ -1,0 +1,23 @@
+import { IUpdateProvider } from "../index"
+
+interface IManifestData {
+
+}
+
+export class GitHubUpdateProvider implements IUpdateProvider {
+	async latestVersion(manifestData: IManifestData): Promise<string | undefined> {
+		throw new Error("Method not implemented.")
+	}
+
+	async updateData(manifestData: IManifestData): Promise<{
+		updateChecksums: boolean
+		prBody?: string | undefined
+		sourceArray?: string[] | undefined
+		source_x86_64?: string[] | undefined
+		source_i686?: string[] | undefined
+		source_aarch64?: string[] | undefined
+		source_armv7h?: string[] | undefined
+	} | undefined> {
+		throw new Error("Method not implemented.")
+	}
+}

--- a/update-package-via-manifest/src/providers/github.ts
+++ b/update-package-via-manifest/src/providers/github.ts
@@ -8,6 +8,8 @@ interface IManifestData {
 }
 
 export class GitHubUpdateProvider implements IUpdateProvider {
+	private lastTagHTMLLink: string | undefined
+
 	async latestVersion(manifestData: IManifestData): Promise<string | undefined> {
 		const split = manifestData.repo.split("/")
 		const owner = split[0]
@@ -34,10 +36,12 @@ export class GitHubUpdateProvider implements IUpdateProvider {
 			return undefined
 		}
 
+		this.lastTagHTMLLink = resp.data.html_url
+
 		return resp.data.tag_name
 	}
 
-	async updateData(manifestData: IManifestData): Promise<{
+	async updateData(_: IManifestData): Promise<{
 		updateChecksums: boolean
 		prBody?: string | undefined
 		sourceArray?: string[] | undefined
@@ -46,8 +50,13 @@ export class GitHubUpdateProvider implements IUpdateProvider {
 		source_aarch64?: string[] | undefined
 		source_armv7h?: string[] | undefined
 	} | undefined> {
+		if (this.lastTagHTMLLink === undefined) {
+			return undefined
+		}
+
 		return {
 			updateChecksums: true,
+			prBody: `_GitHub Release Link:_ [${this.lastTagHTMLLink}](${this.lastTagHTMLLink})`
 		}
 	}
 }

--- a/update-package-via-manifest/src/util.ts
+++ b/update-package-via-manifest/src/util.ts
@@ -1,0 +1,27 @@
+import * as fs from "fs";
+import * as path from "path";
+import { execSync } from "child_process"
+
+export function getVersionFromPKGBUILD(dir: string): string | undefined {
+	const fileContents: string = fs.readFileSync(path.join(dir, "PKGBUILD")).toString()
+
+	const matches = /^pkgver=(.*)$/m.exec(fileContents)
+	if (matches === null) {
+		return undefined
+	}
+
+	return matches[1]
+}
+
+export function hasVersionAlreadyBeenPushed(packageName: string, version: string): boolean {
+	const remoteBranches: string = execSync("git ls-remote --heads origin").toString()
+
+	for (const branch of remoteBranches.split("\n")) {
+		if (branch.indexOf(`${packageName}/${version}`) === -1) {
+			continue
+		}
+		return true
+	}
+
+	return false
+}

--- a/update-package-via-manifest/src/util.ts
+++ b/update-package-via-manifest/src/util.ts
@@ -25,3 +25,43 @@ export function hasVersionAlreadyBeenPushed(packageName: string, version: string
 
 	return false
 }
+
+export function updateSourceArrays(contents: string, arrays: {
+	sourceArray?: Array<string>,
+	source_x86_64?: Array<string>,
+	source_i686?: Array<string>,
+	source_aarch64?: Array<string>,
+	source_armv7h?: Array<string>,
+}): string {
+	if (arrays.sourceArray !== undefined) {
+		contents = contents.replace(/^source=\(.*\)/m, `source=${formatAsBashArray(arrays.sourceArray)}`)
+	}
+
+	if (arrays.source_x86_64 !== undefined) {
+		contents = contents.replace(/^source_x86_64=\(.*\)/m, `source=${formatAsBashArray(arrays.source_x86_64)}`)
+	}
+
+	if (arrays.source_i686 !== undefined) {
+		contents = contents.replace(/^source_i686=\(.*\)/m, `source=${formatAsBashArray(arrays.source_i686)}`)
+	}
+
+	if (arrays.source_aarch64 !== undefined) {
+		contents = contents.replace(/^source_aarch64=\(.*\)/m, `source=${formatAsBashArray(arrays.source_aarch64)}`)
+	}
+
+	if (arrays.source_armv7h !== undefined) {
+		contents = contents.replace(/^source_arm7vh=\(.*\)/m, `source=${formatAsBashArray(arrays.source_armv7h)}`)
+	}
+
+	return contents
+}
+
+function formatAsBashArray(arr: Array<string>): string {
+	let res = ""
+
+	for (const item of arr) {
+		res += `"${item}" `
+	}
+
+	return `(${res.slice(0, res.length - 1)})`
+}


### PR DESCRIPTION
This PR completely restructures the code of `update-package-via-manifest` to allow more features now and in the future.

It also makes the addition of new update providers much easier than before (not that it was particularly hard).