### PR TITLE
[publish-package] Include PR URL in AUR commit

### DIFF
--- a/publish-package/publishpkg.py
+++ b/publish-package/publishpkg.py
@@ -61,6 +61,8 @@ def gen_commit_msg(cwd) -> List[str]:
 	pr_title = event["pull_request"]["title"]
 	pr_num = event["pull_request"]["number"]
 
+	bot_commit_msg = f"Automatically committed from https://github.com/BrenekH/automated-aur/pull/{pr_num}."
+
 	changes = subprocess.check_output(["git", "commit", "--short"], universal_newlines=True, cwd=cwd)
 
 	if "PKGBUILD" in changes:
@@ -78,12 +80,12 @@ def gen_commit_msg(cwd) -> List[str]:
 				pkgver = re.search(r"pkgver=(.*)", pkgbuild_contents).group().replace("pkgver=", "") # Even though I'm using capturing groups,
 				pkgrel = re.search(r"pkgrel=(.*)", pkgbuild_contents).group().replace("pkgrel=", "") # I still need to replace the extra stuff in each line
 
-				return ["-m", f"Update to {pkgver}-{pkgrel}", "-m", "Automatically committed from https://github.com/BrenekH/automated-aur."]
+				return ["-m", f"Update to {pkgver}-{pkgrel}", "-m", bot_commit_msg]
 		except subprocess.CalledProcessError:
 			pass
 
 	# Use PR title as commit title
-	return ["-m", pr_title, "-m", "Automatically committed from https://github.com/BrenekH/automated-aur."]
+	return ["-m", pr_title, "-m", bot_commit_msg]
 
 if __name__ == "__main__":
 	main(sys.argv[1])

--- a/publish-package/publishpkg.py
+++ b/publish-package/publishpkg.py
@@ -38,7 +38,7 @@ def main(_package_dir: str):
 		subprocess.check_call(["git", "add", "-f"] + ["PKGBUILD", ".SRCINFO", ".gitignore"] + manifest["include"],  cwd=git_td)
 
 		print("[INFO] Committing")
-		commit_msg = gen_commit_msg(git_td) + ["-m", "Automatically committed from https://github.com/BrenekH/automated-aur."]
+		commit_msg = gen_commit_msg(git_td)
 		print(commit_msg)
 		subprocess.check_call(["git", "commit"] + commit_msg, cwd=git_td)
 
@@ -73,7 +73,7 @@ def gen_commit_msg(cwd) -> List[str]:
 				pkgver = re.search(r"pkgver=(.*)", pkgbuild_contents).group().replace("pkgver=", "") # Even though I'm using capturing groups,
 				pkgrel = re.search(r"pkgrel=(.*)", pkgbuild_contents).group().replace("pkgrel=", "") # I still need to replace the extra stuff in each line
 
-				return ["-m", f"Update to {pkgver}-{pkgrel}"]
+				return ["-m", f"Update to {pkgver}-{pkgrel}", "-m", "Automatically committed from https://github.com/BrenekH/automated-aur."]
 		except subprocess.CalledProcessError:
 			pass
 
@@ -81,7 +81,7 @@ def gen_commit_msg(cwd) -> List[str]:
 	with Path(os.getenv("GITHUB_EVENT_PATH")).open("r") as f:
 		event = json.load(f)
 
-	return ["-m", event["pull_request"]["title"]]
+	return ["-m", event["pull_request"]["title"], "-m", "Automatically committed from https://github.com/BrenekH/automated-aur."]
 
 if __name__ == "__main__":
 	main(sys.argv[1])

--- a/publish-package/publishpkg.py
+++ b/publish-package/publishpkg.py
@@ -56,6 +56,11 @@ def copy_files_to_dir(files: List[Path], dir: Path):
 		shutil.copy(f, dir / f.name)
 
 def gen_commit_msg(cwd) -> List[str]:
+	with Path(os.getenv("GITHUB_EVENT_PATH")).open("r") as f:
+		event = json.load(f)
+	pr_title = event["pull_request"]["title"]
+	pr_num = event["pull_request"]["number"]
+
 	changes = subprocess.check_output(["git", "commit", "--short"], universal_newlines=True, cwd=cwd)
 
 	if "PKGBUILD" in changes:
@@ -78,10 +83,7 @@ def gen_commit_msg(cwd) -> List[str]:
 			pass
 
 	# Use PR title as commit title
-	with Path(os.getenv("GITHUB_EVENT_PATH")).open("r") as f:
-		event = json.load(f)
-
-	return ["-m", event["pull_request"]["title"], "-m", "Automatically committed from https://github.com/BrenekH/automated-aur."]
+	return ["-m", pr_title, "-m", "Automatically committed from https://github.com/BrenekH/automated-aur."]
 
 if __name__ == "__main__":
 	main(sys.argv[1])


### PR DESCRIPTION
Uses `GITHUB_EVENT_PATH` to construct the PR URL and appends that to the AUR commit message.

Closes #8
