### PR TITLE
[publish-package] Add more restrictions for when to use an "update" commit title

### DIFF
--- a/publish-package/publishpkg.py
+++ b/publish-package/publishpkg.py
@@ -56,7 +56,7 @@ def copy_files_to_dir(files: List[Path], dir: Path):
 		shutil.copy(f, dir / f.name)
 
 def gen_commit_msg(cwd) -> List[str]:
-	with Path(os.getenv("GITHUB_EVENT_PATH")).open("r") as f:
+	with open(os.getenv("GITHUB_EVENT_PATH"), "r") as f:
 		event = json.load(f)
 	pr_title = event["pull_request"]["title"]
 	pr_num = event["pull_request"]["number"]


### PR DESCRIPTION
This PR closes #7 by placing a few more restrictions on when a commit message of `Update to <version>` is used over the original PR title.
Now the PR title must start with "Update", `pkver` must have been updated, and `pkgrel` must be 1, otherwise the PR title is used for the AUR commit.
