### PR TITLE
[update-package-via-manifest] Change from binary URLs to tarball URLs

### DIFF
--- a/update-package-via-manifest/src/index.ts
+++ b/update-package-via-manifest/src/index.ts
@@ -18,6 +18,7 @@ interface IManifest {
 		type: string,
 		repo: string,
 		appID: string,
+		appSlug: string,
 	},
 }
 

--- a/update-package-via-manifest/src/providers/equinox.ts
+++ b/update-package-via-manifest/src/providers/equinox.ts
@@ -41,7 +41,7 @@ export class EquinoxUpdateProvider implements IUpdateProvider {
 	} | undefined> {
 		const targetArches = [
 			["amd64", "x86_64"],
-			["i386", "i686"],
+			["386", "i686"],
 			["arm64", "aarch64"],
 			["arm", "armv7h"],
 		];
@@ -57,7 +57,7 @@ export class EquinoxUpdateProvider implements IUpdateProvider {
 
 		(await this.getLinuxSourceURLs(manifestData.appSlug, latestVersion))?.map((sourceURL: string) => {
 			for (const a of targetArches) {
-				if (sourceURL.includes(a[0] as string)) {
+				if (sourceURL.includes(a[0] as string + ".")) { // Use the beginning of the file extension to ensure arm doesn't match the arm64 url.
 					return {
 						url: sourceURL,
 						arch: a[1] as string,
@@ -69,7 +69,7 @@ export class EquinoxUpdateProvider implements IUpdateProvider {
 		}).forEach((value) => {
 			if (value === undefined) { return; }
 
-			returnObject = Object.assign(returnObject, { [`source_${value.arch}`]: value.url });
+			returnObject = Object.assign(returnObject, { [`source_${value.arch}`]: [value.url] });
 		});
 
 		return returnObject;
@@ -85,7 +85,7 @@ export class EquinoxUpdateProvider implements IUpdateProvider {
 			return undefined;
 		}
 
-		const matches = regex.exec(result.data);
+		const matches = result.data.match(regex);
 		return (matches === null) ? [] : matches;
 	}
 }


### PR DESCRIPTION
Motivated by [https://aur.archlinux.org/packages/ngrok#comment-977848](https://aur.archlinux.org/packages/ngrok#comment-977848).

Basically, to improve the ability to verify the sources, we now query the project's archive page, which has tarballs and hashes which can be easily audited.

- **[equinox-provider] Use the archive page to source download urls instead of the update endpoing**
- **Couple extra little fixes so that the equinox provider works**
